### PR TITLE
Add revision byte hack

### DIFF
--- a/cmd/split.go
+++ b/cmd/split.go
@@ -8,6 +8,8 @@ import (
 var (
 	useFlashID bool
 	useSize    bool
+
+	revisionHack bool
 )
 
 func init() {
@@ -18,12 +20,13 @@ func init() {
 		Long:                  ``,
 		Args:                  cobra.MinimumNArgs(2), //nolint:gomnd
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return split.MemoryCards(args[0], args[1:], useSize, useFlashID) //nolint:wrapcheck
+			return split.MemoryCards(args[0], args[1:], useSize, useFlashID, revisionHack) //nolint:wrapcheck
 		},
 	}
 
 	splitCmd.Flags().BoolVar(&useFlashID, "use-flash-id", false, "use the source memory card flash ID")
 	splitCmd.Flags().BoolVar(&useSize, "use-size", false, "use the source memory card size")
+	splitCmd.Flags().BoolVar(&revisionHack, "revision-bytes", false, "force adding revision bytes to filenames")
 
 	rootCmd.AddCommand(splitCmd)
 }

--- a/internal/split/split.go
+++ b/internal/split/split.go
@@ -23,7 +23,7 @@ var (
 	errUnknownMemoryCard = errors.New("unknown memory card")
 )
 
-func MemoryCards(dir string, files []string, useSize, useFlashID bool) error {
+func MemoryCards(dir string, files []string, useSize, useFlashID, revisionHack bool) error {
 	base, err := filepath.Abs(dir)
 	if err != nil {
 		return fmt.Errorf("unable to create absolute path: %w", err)
@@ -54,7 +54,7 @@ func MemoryCards(dir string, files []string, useSize, useFlashID bool) error {
 			return fmt.Errorf("unable to stat: %w", err)
 		}
 
-		if err := splitMemoryCard(base, file, fi.Size(), useSize, useFlashID); err != nil {
+		if err := splitMemoryCard(base, file, fi.Size(), useSize, useFlashID, revisionHack); err != nil {
 			return err
 		}
 	}
@@ -67,7 +67,7 @@ type fileReader interface {
 	io.ReaderAt
 }
 
-func splitMemoryCard(base string, file fileReader, size int64, useSize, useFlashID bool) error {
+func splitMemoryCard(base string, file fileReader, size int64, useSize, useFlashID, revisionHack bool) error {
 	ok, err := psx.DetectMemoryCard(file, size)
 	if err != nil {
 		return fmt.Errorf("error detecting PlayStation memory card: %w", err)
@@ -83,7 +83,7 @@ func splitMemoryCard(base string, file fileReader, size int64, useSize, useFlash
 	}
 
 	if ok {
-		return splitGCMemoryCard(base, file, useSize, useFlashID)
+		return splitGCMemoryCard(base, file, useSize, useFlashID, revisionHack)
 	}
 
 	return errUnknownMemoryCard

--- a/internal/split/split_internal_test.go
+++ b/internal/split/split_internal_test.go
@@ -17,9 +17,10 @@ func TestMemoryCards(t *testing.T) { //nolint:tparallel
 	t.Parallel()
 
 	tables := []struct {
-		name   string
-		input  []string
-		output map[string][]string
+		name          string
+		input         []string
+		output        map[string][]string
+		revisionBytes bool
 	}{
 		{
 			name: "psx empty",
@@ -101,6 +102,22 @@ func TestMemoryCards(t *testing.T) { //nolint:tparallel
 				"4d0e6ac170b4498cc6e9b433b6823da201f04b8519cb3cb748a799f2c6fae4c5": {"GZLP01", "GZLP01-1.raw"},
 			},
 		},
+		{
+			name: "revision bytes",
+			input: []string{
+				filepath.Join("..", "..", "testdata", "gc", "0251b_2020_04Apr_01_05-02-47.raw"),
+			},
+			output: map[string][]string{
+				"059b275e8c02e34f4242729a2f3189af88169f6f03a0d017f525b5de0dbc20c0": {"G2MP0100", "G2MP0100-1.raw"},
+				"41460a663e223f2f8982f4b6f8c42bc66c2e51d87a642eaf5fa212417aaf7d41": {"G4SP0100", "G4SP0100-1.raw"},
+				"87d239162f3b723681cdace46b6b74ea275ad9616d330fc82f898937598b1a4f": {"GFZP0100", "GFZP0100-1.raw"},
+				"e673c15b1fc7b7fd359288d05807d75515846aad8e802da44b40f8453d0846d9": {"GM8P0100", "GM8P0100-1.raw"},
+				"ae3cfb5d0d8c95a98f1f1cf134a62ce0572ba4f638e481a44d8db6ad79a9962e": {"GPTP4100", "GPTP4100-1.raw"},
+				"ff79db6214bedd51cf13d343cd7c0e36d66079f7ebfd69898a4cbea8802fa3b7": {"GSAP0100", "GSAP0100-1.raw"},
+				"4d0e6ac170b4498cc6e9b433b6823da201f04b8519cb3cb748a799f2c6fae4c5": {"GZLP0100", "GZLP0100-1.raw"},
+			},
+			revisionBytes: true,
+		},
 	}
 
 	for _, table := range tables { //nolint:paralleltest
@@ -116,7 +133,7 @@ func TestMemoryCards(t *testing.T) { //nolint:tparallel
 				t.Fatal(err)
 			}
 
-			if err := MemoryCards(dir, table.input, true, false); err != nil {
+			if err := MemoryCards(dir, table.input, true, false, table.revisionBytes); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Passing `--revision-bytes` forcibly adds `00` to the GameCube directory and file names.